### PR TITLE
Changes to tables and fields naming

### DIFF
--- a/Database/GetTotalClassesSize.sql
+++ b/Database/GetTotalClassesSize.sql
@@ -1,53 +1,51 @@
-CREATE PROCEDURE GetTotalClassesSize
-	(academic_year VARCHAR(50), 
-	semester VARCHAR(50), 
-	faculty VARCHAR(50), 
-	program VARCHAR(50), 
-	module VARCHAR(50), 
-	lecturer VARCHAR(50), 
-	class VARCHAR(50)) 
+DELIMITER $$
+CREATE PROCEDURE `GetTotalClassesSize`(AYCode INT, 
+									   Scode VARCHAR(50), 
+								       Fcode VARCHAR(50), 
+									   Pcode VARCHAR(50), 
+									   Mcode VARCHAR(50), 
+									   Lcode VARCHAR(50), 
+									   Ccode VARCHAR(50))
 BEGIN
 SELECT SUM(c.size)
-FROM Class c
-	JOIN Semester s ON ( c.Scode = s.Scode)
-    JOIN Academic_Year ay ON ( ay.AYCode = s.AYCode)
-    JOIN Module m ON ( c.Mcode = m.Mcode)
-    JOIN Program p ON (m.Pcode = p.Pcode)
-    JOIN Faculty f ON (p.Fcode = f.Fcode)
-    JOIN Lecturer lec ON ( lec.Lcode = (SELECT clec.Lcode
-										FROM Class_has_Lecturer clec 
-										WHERE c.Ccode = clec.Ccode))
+FROM class c
+	JOIN semester s ON ( c.FK_Scode = s.PK_Scode)
+    JOIN academic_year ay1 ON ( ay.PK_AYCode = s.FK_AYCode)
+    JOIN module m ON ( c.FK_Mcode = m.PK_Mcode)
+    JOIN program p ON (m.FK_Pcode = p.PK_Pcode)
+    JOIN faculty f ON (p.FK_Fcode = f.PK_Fcode)
+    JOIN academic_year ay2 ON ( ay.PK_AYCode = f.FK_AYCode)
+    JOIN lecturer lec ON ( lec.Lcode = (SELECT cl.FK_Lcode
+										FROM class_has_lecturer cl 
+										WHERE c.PK_Ccode = cl.FK_Ccode))
 WHERE 
 	( academic_year is null
-      or ay.AYCode = academic_year
+      or ay.PK_AYCode = AYCode
 	)
 AND
 	( semester is null
-      or s.Scode = semester
+      or s.PK_Scode = Scode
 	)
 AND
 	( faculty is null
-      or f.Fcode = faculty
+      or f.PK_Fcode = Fcode
 	)
 AND
 	( program is null
-      or p.Pcode = program
+      or p.PK_Pcode = Pcode
 	)
 AND
 	( module is null
-      or m.Mcode = module
+      or m.PK_Mcode = Mcode
 	)
 AND
 	( lecturer is null
-      or lec.Lcode = lecturer
+      or lec.PK_Lcode = Lcode
 	)
 AND
 	( class is null
-      or c.Ccode = class
+      or c.PK_Ccode = Ccode
 	)
-End;
-
-    
-
-
-
+;
+END$$
+DELIMITER ;

--- a/Database/Group2_Database.sql
+++ b/Database/Group2_Database.sql
@@ -1,0 +1,87 @@
+CREATE TABLE `academic_year` (
+  `PK_AYCode` int NOT NULL,
+  PRIMARY KEY (`PK_AYCode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `class` (
+  `PK_Ccode` varchar(50) NOT NULL,
+  `size` int DEFAULT NULL,
+  `FK_Scode` varchar(50) DEFAULT NULL,
+  `FK_Mcode` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`PK_Ccode`),
+  KEY `class_semester_Scode` (`FK_Scode`),
+  KEY `class_module_Mcode` (`FK_Mcode`),
+  CONSTRAINT `class_module_Mcode` FOREIGN KEY (`FK_Mcode`) REFERENCES `module` (`PK_Mcode`),
+  CONSTRAINT `class_semester_Scode` FOREIGN KEY (`FK_Scode`) REFERENCES `semester` (`PK_Scode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `class_has_lecturer` (
+  `FK_Ccode` varchar(50) NOT NULL,
+  `FK_Lcode` varchar(50) NOT NULL,
+  PRIMARY KEY (`FK_Ccode`,`FK_Lcode`),
+  KEY `cl_lecturer_Lcode` (`FK_Lcode`),
+  CONSTRAINT `cl_class_Ccode` FOREIGN KEY (`FK_Ccode`) REFERENCES `class` (`PK_Ccode`),
+  CONSTRAINT `cl_lecturer_Lcode` FOREIGN KEY (`FK_Lcode`) REFERENCES `lecturer` (`PK_Lcode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `faculty` (
+  `PK_Fcode` varchar(50) NOT NULL,
+  `Fname` varchar(50) DEFAULT NULL,
+  `FK_AYCode` int DEFAULT NULL,
+  PRIMARY KEY (`PK_Fcode`),
+  KEY `faculty_academicyear_AYCode` (`FK_AYCode`),
+  CONSTRAINT `faculty_academicyear_AYCode` FOREIGN KEY (`FK_AYCode`) REFERENCES `academic_year` (`PK_AYCode`) ON UPDATE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `lecturer` (
+  `PK_Lcode` varchar(50) NOT NULL,
+  `Lname` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`PK_Lcode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `module` (
+  `PK_Mcode` varchar(50) NOT NULL,
+  `Mname` varchar(50) DEFAULT NULL,
+  `FK_Pcode` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`PK_Mcode`),
+  KEY `module_program_Pcode` (`FK_Pcode`),
+  CONSTRAINT `module_program_Pcode` FOREIGN KEY (`FK_Pcode`) REFERENCES `program` (`PK_Pcode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `module_program_in_ay` (
+  `FK_AYCode` int NOT NULL,
+  `FK_Mcode` varchar(50) NOT NULL,
+  `FK_Pcode` varchar(50) NOT NULL,
+  PRIMARY KEY (`FK_AYCode`,`FK_Mcode`,`FK_Pcode`),
+  KEY `mpa_module_Mcode` (`FK_Mcode`),
+  KEY `mpa_program_Pcode` (`FK_Pcode`),
+  CONSTRAINT `mpa_academicyear_AYCode` FOREIGN KEY (`FK_AYCode`) REFERENCES `academic_year` (`PK_AYCode`),
+  CONSTRAINT `mpa_module_Mcode` FOREIGN KEY (`FK_Mcode`) REFERENCES `module` (`PK_Mcode`),
+  CONSTRAINT `mpa_program_Pcode` FOREIGN KEY (`FK_Pcode`) REFERENCES `program` (`PK_Pcode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `program` (
+  `PK_Pcode` varchar(50) NOT NULL,
+  `Pname` varchar(50) DEFAULT NULL,
+  `FK_Fcode` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`PK_Pcode`),
+  KEY `program_faculty_Fcode` (`FK_Fcode`),
+  CONSTRAINT `program_faculty_Fcode` FOREIGN KEY (`FK_Fcode`) REFERENCES `faculty` (`PK_Fcode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `questionaire` (
+  `FK_Ccode` varchar(50) NOT NULL,
+  `FK_Lcode` varchar(50) NOT NULL,
+  PRIMARY KEY (`FK_Ccode`,`FK_Lcode`),
+  KEY `questionaire_lecturer_Lcode` (`FK_Lcode`),
+  CONSTRAINT `questionaire_class_Ccode` FOREIGN KEY (`FK_Ccode`) REFERENCES `class` (`PK_Ccode`),
+  CONSTRAINT `questionaire_lecturer_Lcode` FOREIGN KEY (`FK_Lcode`) REFERENCES `lecturer` (`PK_Lcode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `semester` (
+  `PK_Scode` varchar(50) NOT NULL,
+  `FK_AYCode` int DEFAULT NULL,
+  PRIMARY KEY (`PK_Scode`),
+  KEY `semester_academicyear_AYCode` (`FK_AYCode`),
+  CONSTRAINT `semester_academicyear_AYCode` FOREIGN KEY (`FK_AYCode`) REFERENCES `academic_year` (`PK_AYCode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
- Primary keys have 'PK_' prefix
- Foreign keys have 'FK_' prefix
- Constraint names (have to be unique) are in the form: current table _ parent table_ column name
**These 2 files replace the initial ones**